### PR TITLE
fix: docker compose settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# company-lens
-# company-lens
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed on your machine
+- [Docker Compose](https://docs.docker.com/compose/install/) (included with Docker Desktop on Mac and Windows)
+
+### Starting the services
+
+To start both services in the foreground (showing logs in the terminal):
+
+```bash
+docker compose up -d
+```
+
+### If container already exist
+
+#### 1. Start existing containers (if they're stopped):
+
+```bash
+docker start company-lens-db company-lens-redis
+```
+
+
+#### 2. Restart running containers:
+
+```bash
+docker restart company-lens-db company-lens-redis
+```
+
+#### 3. Stop the containers:
+
+```bash
+docker stop company-lens-db company-lens-redis
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     container_name: company-lens-db
@@ -12,9 +10,12 @@ services:
       - POSTGRES_DB=postgres
     ports:
       - "5432:5432"
-
+      
   redis:
     container_name: company-lens-redis
     image: redis:latest
     ports:
       - "6379:6379"
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
# Fix Docker Compose Configuration

## Changes Made
- Removed obsolete `version: '3.8'` from docker-compose.yml
- Added top-level `volumes` section with `postgres_data` volume
- Updated README with instructions for running and managing containers

## Problem Solved
This PR fixes the errors:
- "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
- "service 'db' refers to undefined volume postgres_data: invalid compose project"
